### PR TITLE
Added localizations for DPS and total damage toggle

### DIFF
--- a/localization/en-us.xml
+++ b/localization/en-us.xml
@@ -1651,6 +1651,12 @@
             <Setting Id="DAMAGE_METER_ENABLE_OTOMOS"
                      String="Show Otomos damage"
                      Description="If enabled, HunterPie will display Otomos damage." />
+            <Setting Id="DAMAGE_METER_SHOULD_SHOW_DPS"
+                     String="Show DPS"
+                     Description="If enabled, HunterPie will display each player's DPS." />
+            <Setting Id="DAMAGE_METER_SHOULD_SHOW_DAMAGE"
+                     String="Show total damage"
+                     Description="If enabled, HunterPie will display each player's total damage." />
             <Setting Id="DEV_MOCK_MONSTER_WIDGET_STRING"
                      String="Developer: Mock Monster widget"
                      Description="DO NOT ENABLE IF YOU DO NOT KNOW WHAT YOU ARE DOING." />


### PR DESCRIPTION
Client PR: https://github.com/HunterPie/HunterPie/pull/510

This adds options to HunterPie to display or hide DPS/total damage on the damage widget. I found the older PR for this: #73, and this should incorporate the suggestions from that one.